### PR TITLE
ndctl: disable unit test

### DIFF
--- a/Makefile.lb
+++ b/Makefile.lb
@@ -10,7 +10,6 @@ build:
 	cd $(NDCTL_DIR) && ./autogen.sh
 	cd $(NDCTL_DIR) && ./configure CFLAGS='-g -O0' --prefix=$(NDCTL_UTIL_INSTALL_DIR) --sysconfdir=/etc --libdir=$(NDCTL_UTIL_INSTALL_DIR)/lib
 	$(Q)$(MAKE)
-	$(Q)$(MAKE) check
 
 install:
 	$(Q)$(MAKE) install


### PR DESCRIPTION
check target fails to build.
FAIL: multi-dax.sh because nfit_test.ko is not found (not standard).
README.md explains how to clone and build it to pass unit test.

Disabling the unit test.

Issue: LBM1-4229

Signed-off-by: Anton <anton@lightbitslabs.com>